### PR TITLE
feat: Add automatic ATA derivation to TypeScript client

### DIFF
--- a/program/clients/typescript/tests/integration/helpers/state-utils.ts
+++ b/program/clients/typescript/tests/integration/helpers/state-utils.ts
@@ -17,11 +17,7 @@ import {
   findMerchantPda,
   findMerchantOperatorConfigPda,
   getCreateOperatorInstruction,
-  getInitializeMerchantInstruction,
   getInitializeMerchantOperatorConfigInstruction,
-  getMakePaymentInstruction,
-  getClearPaymentInstruction,
-  getRefundPaymentInstruction,
   getClosePaymentInstruction,
   getUpdateMerchantSettlementWalletInstruction,
   getUpdateMerchantAuthorityInstruction,
@@ -29,6 +25,10 @@ import {
   FeeType,
   PolicyData,
   Status,
+  getInitializeMerchantInstructionAsync,
+  getMakePaymentInstructionAsync,
+  getRefundPaymentInstructionAsync,
+  getClearPaymentInstructionAsync,
 } from "../../../src/generated";
 import { sendAndConfirmInstructions } from "./transactions";
 import {
@@ -177,21 +177,12 @@ export async function assertGetOrCreateMerchant({
   });
 
   // Initialize merchant instruction
-  const initMerchantIx = getInitializeMerchantInstruction({
+  const initMerchantIx = await getInitializeMerchantInstructionAsync({
     bump,
     payer: payer,
     authority: authority,
     merchant: merchantPda,
     settlementWallet: settlementWallet.address,
-    systemProgram: SYSTEM_PROGRAM_ADDRESS,
-    settlementUsdcAta,
-    escrowUsdcAta,
-    usdcMint,
-    settlementUsdtAta,
-    escrowUsdtAta,
-    usdtMint,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
   });
 
   await sendAndConfirmInstructions({
@@ -366,7 +357,7 @@ export async function assertMakePayment({
     merchantEscrowAta
   );
 
-  const payment = getMakePaymentInstruction({
+  const payment = await getMakePaymentInstructionAsync({
     payer,
     payment: paymentPda,
     operatorAuthority,
@@ -375,8 +366,6 @@ export async function assertMakePayment({
     merchant: merchantPda,
     merchantOperatorConfig: merchantOperatorConfigPda,
     mint,
-    buyerAta,
-    merchantEscrowAta,
     merchantSettlementAta,
     orderId,
     amount,
@@ -486,7 +475,7 @@ export async function assertClearPayment({
     [operatorSettlementAta, operatorSettlementPreBalance],
   ]);
 
-  const clearPaymentIx = getClearPaymentInstruction({
+  const clearPaymentIx = await getClearPaymentInstructionAsync({
     payer,
     payment: paymentPda,
     operatorAuthority,
@@ -495,12 +484,7 @@ export async function assertClearPayment({
     operator: operatorPda,
     merchantOperatorConfig: merchantOperatorConfigPda,
     mint,
-    merchantEscrowAta,
     merchantSettlementAta,
-    operatorSettlementAta,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-    systemProgram: SYSTEM_PROGRAM_ADDRESS,
   });
 
   await sendAndConfirmInstructions({
@@ -604,7 +588,7 @@ export async function assertRefundPayment({
     [buyerAta, buyerPreBalance],
   ]);
 
-  const refundPaymentIx = getRefundPaymentInstruction({
+  const refundPaymentIx = await getRefundPaymentInstructionAsync({
     payer,
     payment: paymentPda,
     operatorAuthority,
@@ -613,10 +597,6 @@ export async function assertRefundPayment({
     operator: operatorPda,
     merchantOperatorConfig: merchantOperatorConfigPda,
     mint,
-    merchantEscrowAta,
-    buyerAta,
-    tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    systemProgram: SYSTEM_PROGRAM_ADDRESS,
   });
 
   await sendAndConfirmInstructions({

--- a/program/clients/typescript/tests/setup/mocks.ts
+++ b/program/clients/typescript/tests/setup/mocks.ts
@@ -31,19 +31,19 @@ export const mockTransactionSigner = (address: Address): TransactionSigner => ({
  * Common test addresses for consistent testing
  */
 export const TEST_ADDRESSES = {
-  PAYER: '11111111111111111111111111111111' as Address,
-  AUTHORITY: '22222222222222222222222222222222' as Address,
-  MERCHANT: '33333333333333333333333333333333' as Address,
-  OPERATOR: '44444444444444444444444444444444' as Address,
-  BUYER: '55555555555555555555555555555555' as Address,
-  PAYMENT: '66666666666666666666666666666666' as Address,
-  CONFIG: '77777777777777777777777777777777' as Address,
-  MINT: '88888888888888888888888888888888' as Address,
-  ATA_1: '99999999999999999999999999999999' as Address,
-  ATA_2: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Address,
-  ATA_3: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Address,
-  SETTLEMENT_WALLET: 'cccccccccccccccccccccccccccccccc' as Address,
-  NEW_AUTHORITY: 'dddddddddddddddddddddddddddddddd' as Address,
+  PAYER: '11111111111111111111111111111112' as Address,
+  AUTHORITY: '4aMgkHVGzK3FAhWvJRpCpG2kTkA4dxUQSGfPbhpZsDbF' as Address,
+  MERCHANT: '5JYdXKJLwfCWQdR7aBe6L1zjwvBJHXEemMVgXQM97C8V' as Address,
+  OPERATOR: '6cPFGPZbUE7DQPrw24GgTYNkvr2FLnHfgqgjCxEn73K5' as Address,
+  BUYER: '7BgH7Hq2P3CsQQ2DgJtfHPNNdJtKJsKJGJhRPNkkvuY3' as Address,
+  PAYMENT: '8MKrYq1F8xKhXp4FJWfYSgYZNgPqvP3DQa2Jv7rXfQN8' as Address,
+  CONFIG: '9LqZxwCF5N4FdpTJGcZpYPvT2GcLXMdNzQf5EyN5DhYx' as Address,
+  MINT: 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address,
+  ATA_1: 'BT8z9sLZJdwHuZNwgXK4VdCkRGCkF7FZqN2vKNmM4xP1' as Address,
+  ATA_2: 'CAnQK3i5FBdWr2GZjmX3VqrP8F3n7qWfNBhRndfzKu42' as Address,
+  ATA_3: 'DPmwVvvvV7WfQqKNWdxnKjVnCJHBDvhQFd7Pb2FQFQFQ' as Address,
+  SETTLEMENT_WALLET: 'EqSF9rK3aVvLpPXgVg6KzVBwX8FqQn2xN5nCvPtPGxMZ' as Address,
+  NEW_AUTHORITY: 'F1tJFQPgGK2cNgvBZ2L7rXdRpVvMgKqWzFnrNZ9K6X2P' as Address,
 } as const;
 
 /**

--- a/program/clients/typescript/tests/unit/instructions/chargeback-payment.test.ts
+++ b/program/clients/typescript/tests/unit/instructions/chargeback-payment.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@jest/globals";
 import {
   getChargebackPaymentInstruction,
+  getChargebackPaymentInstructionAsync,
   CHARGEBACK_PAYMENT_DISCRIMINATOR,
 } from "../../../src/generated";
 import { AccountRole } from "gill";
@@ -9,6 +10,10 @@ import {
   TEST_ADDRESSES,
   EXPECTED_PROGRAM_ADDRESS,
 } from "../../../tests/setup/mocks";
+import { 
+  TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda 
+} from 'gill/programs';
 
 describe("chargebackPayment", () => {
   it("should create a valid chargeback payment instruction", () => {
@@ -51,5 +56,124 @@ describe("chargebackPayment", () => {
     // Test data
     const expectedData = new Uint8Array([CHARGEBACK_PAYMENT_DISCRIMINATOR]);
     expect(instruction.data).toEqual(expectedData);
+  });
+
+  describe('automatic ATA derivation', () => {
+    it('should automatically derive merchantEscrowAta when not provided', async () => {
+      const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
+      const operatorAuthority = mockTransactionSigner(TEST_ADDRESSES.AUTHORITY);
+
+      // Get expected ATA address using findAssociatedTokenPda
+      const [expectedMerchantEscrowAta] = await findAssociatedTokenPda({
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        mint: TEST_ADDRESSES.MINT,
+        owner: TEST_ADDRESSES.MERCHANT,
+      });
+
+      // Generate instruction without providing merchantEscrowAta - should be auto-derived
+      const instruction = await getChargebackPaymentInstructionAsync({
+        payer,
+        payment: TEST_ADDRESSES.PAYMENT,
+        operatorAuthority,
+        buyer: TEST_ADDRESSES.BUYER,
+        merchant: TEST_ADDRESSES.MERCHANT,
+        operator: TEST_ADDRESSES.OPERATOR,
+        merchantOperatorConfig: TEST_ADDRESSES.CONFIG,
+        mint: TEST_ADDRESSES.MINT,
+        // Not providing merchantEscrowAta - should be auto-derived
+      });
+
+      // Verify the automatically derived merchantEscrowAta matches expected address
+      expect(instruction.accounts[8].address).toBe(expectedMerchantEscrowAta); // merchantEscrowAta
+    });
+
+    it('should automatically derive buyerAta when not provided', async () => {
+      const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
+      const operatorAuthority = mockTransactionSigner(TEST_ADDRESSES.AUTHORITY);
+
+      // Get expected ATA address using findAssociatedTokenPda
+      const [expectedBuyerAta] = await findAssociatedTokenPda({
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        mint: TEST_ADDRESSES.MINT,
+        owner: TEST_ADDRESSES.BUYER,
+      });
+
+      // Generate instruction without providing buyerAta - should be auto-derived
+      const instruction = await getChargebackPaymentInstructionAsync({
+        payer,
+        payment: TEST_ADDRESSES.PAYMENT,
+        operatorAuthority,
+        buyer: TEST_ADDRESSES.BUYER,
+        merchant: TEST_ADDRESSES.MERCHANT,
+        operator: TEST_ADDRESSES.OPERATOR,
+        merchantOperatorConfig: TEST_ADDRESSES.CONFIG,
+        mint: TEST_ADDRESSES.MINT,
+        // Not providing buyerAta - should be auto-derived
+      });
+
+      // Verify the automatically derived buyerAta matches expected address
+      expect(instruction.accounts[9].address).toBe(expectedBuyerAta); // buyerAta
+    });
+
+    it('should automatically derive both ATAs when not provided', async () => {
+      const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
+      const operatorAuthority = mockTransactionSigner(TEST_ADDRESSES.AUTHORITY);
+
+      // Get expected ATA addresses using findAssociatedTokenPda
+      const [expectedMerchantEscrowAta] = await findAssociatedTokenPda({
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        mint: TEST_ADDRESSES.MINT,
+        owner: TEST_ADDRESSES.MERCHANT,
+      });
+
+      const [expectedBuyerAta] = await findAssociatedTokenPda({
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        mint: TEST_ADDRESSES.MINT,
+        owner: TEST_ADDRESSES.BUYER,
+      });
+
+      // Generate instruction without providing any ATAs - should be auto-derived
+      const instruction = await getChargebackPaymentInstructionAsync({
+        payer,
+        payment: TEST_ADDRESSES.PAYMENT,
+        operatorAuthority,
+        buyer: TEST_ADDRESSES.BUYER,
+        merchant: TEST_ADDRESSES.MERCHANT,
+        operator: TEST_ADDRESSES.OPERATOR,
+        merchantOperatorConfig: TEST_ADDRESSES.CONFIG,
+        mint: TEST_ADDRESSES.MINT,
+        // Not providing merchantEscrowAta or buyerAta - should be auto-derived
+      });
+
+      // Verify both automatically derived ATAs match expected addresses
+      expect(instruction.accounts[8].address).toBe(expectedMerchantEscrowAta); // merchantEscrowAta
+      expect(instruction.accounts[9].address).toBe(expectedBuyerAta); // buyerAta
+    });
+
+    it('should use provided ATA addresses when supplied (override auto-derivation)', async () => {
+      const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
+      const operatorAuthority = mockTransactionSigner(TEST_ADDRESSES.AUTHORITY);
+
+      // Provide custom ATA addresses
+      const customMerchantEscrowAta = TEST_ADDRESSES.ATA_1;
+      const customBuyerAta = TEST_ADDRESSES.ATA_2;
+
+      const instruction = await getChargebackPaymentInstructionAsync({
+        payer,
+        payment: TEST_ADDRESSES.PAYMENT,
+        operatorAuthority,
+        buyer: TEST_ADDRESSES.BUYER,
+        merchant: TEST_ADDRESSES.MERCHANT,
+        operator: TEST_ADDRESSES.OPERATOR,
+        merchantOperatorConfig: TEST_ADDRESSES.CONFIG,
+        mint: TEST_ADDRESSES.MINT,
+        merchantEscrowAta: customMerchantEscrowAta,
+        buyerAta: customBuyerAta,
+      });
+
+      // Verify the provided addresses are used instead of auto-derived ones
+      expect(instruction.accounts[8].address).toBe(customMerchantEscrowAta); // merchantEscrowAta
+      expect(instruction.accounts[9].address).toBe(customBuyerAta); // buyerAta
+    });
   });
 });

--- a/program/clients/typescript/tests/unit/instructions/make-payment.test.ts
+++ b/program/clients/typescript/tests/unit/instructions/make-payment.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@jest/globals";
 import {
   getMakePaymentInstruction,
+  getMakePaymentInstructionAsync,
   MAKE_PAYMENT_DISCRIMINATOR,
 } from "../../../src/generated";
 import { AccountRole } from "gill";
@@ -9,6 +10,10 @@ import {
   TEST_ADDRESSES,
   EXPECTED_PROGRAM_ADDRESS,
 } from "../../../tests/setup/mocks";
+import { 
+  TOKEN_PROGRAM_ADDRESS,
+  findAssociatedTokenPda 
+} from 'gill/programs';
 
 describe("makePayment", () => {
   it("should create a valid make payment instruction", () => {
@@ -57,5 +62,144 @@ describe("makePayment", () => {
     // Test data
     const expectedDiscriminator = new Uint8Array([MAKE_PAYMENT_DISCRIMINATOR]);
     expect(instruction.data.slice(0, 1)).toEqual(expectedDiscriminator);
+  });
+
+  describe('automatic ATA derivation', () => {
+    it('should automatically derive buyerAta when not provided', async () => {
+      const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
+      const operatorAuthority = mockTransactionSigner(TEST_ADDRESSES.AUTHORITY);
+      const buyer = mockTransactionSigner(TEST_ADDRESSES.BUYER);
+
+      // Get expected ATA address using findAssociatedTokenPda
+      const [expectedBuyerAta] = await findAssociatedTokenPda({
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        mint: TEST_ADDRESSES.MINT,
+        owner: TEST_ADDRESSES.BUYER,
+      });
+
+      // Generate instruction without providing buyerAta - should be auto-derived
+      const instruction = await getMakePaymentInstructionAsync({
+        payer,
+        payment: TEST_ADDRESSES.PAYMENT,
+        operatorAuthority,
+        buyer,
+        operator: TEST_ADDRESSES.OPERATOR,
+        merchant: TEST_ADDRESSES.MERCHANT,
+        merchantOperatorConfig: TEST_ADDRESSES.CONFIG,
+        mint: TEST_ADDRESSES.MINT,
+        merchantSettlementAta: TEST_ADDRESSES.ATA_3,
+        orderId: 1,
+        amount: 100,
+        bump: 255,
+        // Not providing buyerAta - should be auto-derived
+      });
+
+      // Verify the automatically derived buyerAta matches expected address
+      expect(instruction.accounts[8].address).toBe(expectedBuyerAta); // buyerAta
+    });
+
+    it('should automatically derive merchantEscrowAta when not provided', async () => {
+      const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
+      const operatorAuthority = mockTransactionSigner(TEST_ADDRESSES.AUTHORITY);
+      const buyer = mockTransactionSigner(TEST_ADDRESSES.BUYER);
+
+      // Get expected ATA address using findAssociatedTokenPda
+      const [expectedMerchantEscrowAta] = await findAssociatedTokenPda({
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        mint: TEST_ADDRESSES.MINT,
+        owner: TEST_ADDRESSES.MERCHANT,
+      });
+
+      // Generate instruction without providing merchantEscrowAta - should be auto-derived
+      const instruction = await getMakePaymentInstructionAsync({
+        payer,
+        payment: TEST_ADDRESSES.PAYMENT,
+        operatorAuthority,
+        buyer,
+        operator: TEST_ADDRESSES.OPERATOR,
+        merchant: TEST_ADDRESSES.MERCHANT,
+        merchantOperatorConfig: TEST_ADDRESSES.CONFIG,
+        mint: TEST_ADDRESSES.MINT,
+        merchantSettlementAta: TEST_ADDRESSES.ATA_3,
+        orderId: 1,
+        amount: 100,
+        bump: 255,
+        // Not providing merchantEscrowAta - should be auto-derived
+      });
+
+      // Verify the automatically derived merchantEscrowAta matches expected address
+      expect(instruction.accounts[9].address).toBe(expectedMerchantEscrowAta); // merchantEscrowAta
+    });
+
+    it('should automatically derive both buyerAta and merchantEscrowAta when not provided', async () => {
+      const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
+      const operatorAuthority = mockTransactionSigner(TEST_ADDRESSES.AUTHORITY);
+      const buyer = mockTransactionSigner(TEST_ADDRESSES.BUYER);
+
+      // Get expected ATA addresses using findAssociatedTokenPda
+      const [expectedBuyerAta] = await findAssociatedTokenPda({
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        mint: TEST_ADDRESSES.MINT,
+        owner: TEST_ADDRESSES.BUYER,
+      });
+
+      const [expectedMerchantEscrowAta] = await findAssociatedTokenPda({
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        mint: TEST_ADDRESSES.MINT,
+        owner: TEST_ADDRESSES.MERCHANT,
+      });
+
+      // Generate instruction without providing any ATAs - should be auto-derived
+      const instruction = await getMakePaymentInstructionAsync({
+        payer,
+        payment: TEST_ADDRESSES.PAYMENT,
+        operatorAuthority,
+        buyer,
+        operator: TEST_ADDRESSES.OPERATOR,
+        merchant: TEST_ADDRESSES.MERCHANT,
+        merchantOperatorConfig: TEST_ADDRESSES.CONFIG,
+        mint: TEST_ADDRESSES.MINT,
+        merchantSettlementAta: TEST_ADDRESSES.ATA_3,
+        orderId: 1,
+        amount: 100,
+        bump: 255,
+        // Not providing buyerAta or merchantEscrowAta - should be auto-derived
+      });
+
+      // Verify both automatically derived ATAs match expected addresses
+      expect(instruction.accounts[8].address).toBe(expectedBuyerAta); // buyerAta
+      expect(instruction.accounts[9].address).toBe(expectedMerchantEscrowAta); // merchantEscrowAta
+    });
+
+    it('should use provided ATA addresses when supplied (override auto-derivation)', async () => {
+      const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
+      const operatorAuthority = mockTransactionSigner(TEST_ADDRESSES.AUTHORITY);
+      const buyer = mockTransactionSigner(TEST_ADDRESSES.BUYER);
+
+      // Provide custom ATA addresses
+      const customBuyerAta = TEST_ADDRESSES.ATA_1;
+      const customMerchantEscrowAta = TEST_ADDRESSES.ATA_2;
+
+      const instruction = await getMakePaymentInstructionAsync({
+        payer,
+        payment: TEST_ADDRESSES.PAYMENT,
+        operatorAuthority,
+        buyer,
+        operator: TEST_ADDRESSES.OPERATOR,
+        merchant: TEST_ADDRESSES.MERCHANT,
+        merchantOperatorConfig: TEST_ADDRESSES.CONFIG,
+        mint: TEST_ADDRESSES.MINT,
+        buyerAta: customBuyerAta,
+        merchantEscrowAta: customMerchantEscrowAta,
+        merchantSettlementAta: TEST_ADDRESSES.ATA_3,
+        orderId: 1,
+        amount: 100,
+        bump: 255,
+      });
+
+      // Verify the provided addresses are used instead of auto-derived ones
+      expect(instruction.accounts[8].address).toBe(customBuyerAta); // buyerAta
+      expect(instruction.accounts[9].address).toBe(customMerchantEscrowAta); // merchantEscrowAta
+    });
   });
 });


### PR DESCRIPTION
Improves developer experience by automatically deriving Associated Token Account (ATA) addresses from existing instruction parameters, eliminating the need for manual ATA computation in most cases.

### Changes

Client Generation (scripts/generate-client.js)

- Added automatic ATA derivation using Codama's `pdaValueNode` for payment instructions
- Created helper function `createAtaPdaValueNode` to generate ATA addresses from owner and mint accounts
- Applied derivation to `initializeMerchant`, `makePayment`, `refundPayment`, `clearPayment`, and `chargebackPayment`

Generated Instructions

- ATA parameters are now optional in async instruction functions (findAta is async)
- ATAs automatically computed using standard derivation algorithm when not provided
- Users can still override automatic derivation by providing explicit addresses

Test Coverage

- Added comprehensive unit tests for all instructions with ATA derivation
- Tests verify derived addresses match `findAssociatedTokenPda` results
- Coverage for automatic derivation, override behavior, and edge cases
- All tests passing

 Developer Experience Impact

  Before:

```
  const [settlementUsdcAta] = await findAssociatedTokenPda({...});
  const [escrowUsdcAta] = await findAssociatedTokenPda({...});
  // Repeat for all ATAs...

  const instruction = getInitializeMerchantInstruction({
    settlementUsdcAta,
    escrowUsdcAta,
    // ... other ATAs
  });
```

  After:
  const instruction = await getInitializeMerchantInstructionAsync({
    payer,
    authority,
    merchant,
    settlementWallet,
    bump,
    // ATAs automatically derived from existing accounts
  });

  Affected Instructions

- initializeMerchant: Auto-derives 4 ATAs (settlement/escrow for USDC/USDT)
- makePayment: Auto-derives buyer and merchant escrow ATAs
- refundPayment: Auto-derives buyer and merchant escrow ATAs
- clearPayment: Auto-derives merchant escrow and operator settlement ATAs
- chargebackPayment: Auto-derives buyer 